### PR TITLE
Add option to jump if already open and/or open in new tab

### DIFF
--- a/plugin/neovim-fuzzy.vim
+++ b/plugin/neovim-fuzzy.vim
@@ -14,17 +14,6 @@ let s:fuzzy_job_id = 0
 let s:fuzzy_prev_window = -1
 let s:fuzzy_prev_window_height = -1
 
-if ! exists("g:fuzzy_opencmd")
-  let g:fuzzy_opencmd = "edit"
-endif
-if ! exists("g:fuzzy_tabopen")
-  let g:fuzzy_tabopen = 0
-endif
-if ! exists("g:fuzzy_jump_if_open")
-  let g:fuzzy_jump_if_open = 0
-endif
-
-
 command! FuzzyOpen call s:fuzzy()
 command! FuzzyKill call s:fuzzy_kill()
 
@@ -41,22 +30,8 @@ function! s:fuzzy() abort
   let outputs = tempname()
   let ignores = tempname()
 
-  if exists("g:fuzzy_opencmd")
-    " overrride toggle options
-    let s:fuzzy_open_command = g:fuzzy_opencmd
-  else
-    " use toggle options
-    let s:fuzzy_open_command = ''
-
-    if g:fuzzy_tabopen
-      let s:fuzzy_open_command = 'tab'
-    endif
-
-    if g:fuzzy_jump_if_open
-      let s:fuzzy_open_command .= ' drop' "drop or tab drop
-    else
-      let s:fuzzy_open_command .= 'edit' "edit or tabedit
-    endif
+  if ! exists("g:fuzzy_opencmd")
+    let g:fuzzy_opencmd = 'edit'
   endif
 
   " Get open buffers.
@@ -96,7 +71,7 @@ function! s:fuzzy() abort
 
     let result = readfile(self.outputs)
     if !empty(result)
-      execute s:fuzzy_open_command fnameescape(join(result))
+      execute g:fuzzy_opencmd fnameescape(join(result))
     endif
   endfunction
 

--- a/plugin/neovim-fuzzy.vim
+++ b/plugin/neovim-fuzzy.vim
@@ -14,6 +14,9 @@ let s:fuzzy_job_id = 0
 let s:fuzzy_prev_window = -1
 let s:fuzzy_prev_window_height = -1
 
+if ! exists("g:fuzzy_opencmd")
+  let g:fuzzy_opencmd = "edit"
+endif
 if ! exists("g:fuzzy_tabopen")
   let g:fuzzy_tabopen = 0
 endif
@@ -38,17 +41,24 @@ function! s:fuzzy() abort
   let outputs = tempname()
   let ignores = tempname()
 
-  let s:fuzzy_open_command = ''
-
-  if g:fuzzy_tabopen
-    let s:fuzzy_open_command = 'tab'
-  endif
-
-  if g:fuzzy_jump_if_open
-    let s:fuzzy_open_command .= ' drop' "drop or tab drop
+  if exists("g:fuzzy_opencmd")
+    " overrride toggle options
+    let s:fuzzy_open_command = g:fuzzy_opencmd
   else
-    let s:fuzzy_open_command .= 'edit' "edit or tabedit
+    " use toggle options
+    let s:fuzzy_open_command = ''
+
+    if g:fuzzy_tabopen
+      let s:fuzzy_open_command = 'tab'
+    endif
+
+    if g:fuzzy_jump_if_open
+      let s:fuzzy_open_command .= ' drop' "drop or tab drop
+    else
+      let s:fuzzy_open_command .= 'edit' "edit or tabedit
+    endif
   endif
+
   " Get open buffers.
   let bufs = filter(range(1, bufnr('$')),
     \ 'buflisted(v:val) && bufnr("%") != v:val && bufnr("#") != v:val')

--- a/plugin/neovim-fuzzy.vim
+++ b/plugin/neovim-fuzzy.vim
@@ -14,6 +14,14 @@ let s:fuzzy_job_id = 0
 let s:fuzzy_prev_window = -1
 let s:fuzzy_prev_window_height = -1
 
+if ! exists("g:fuzzy_tabopen")
+  let g:fuzzy_tabopen = 0
+endif
+if ! exists("g:fuzzy_jump_if_open")
+  let g:fuzzy_jump_if_open = 0
+endif
+
+
 command! FuzzyOpen call s:fuzzy()
 command! FuzzyKill call s:fuzzy_kill()
 
@@ -30,6 +38,17 @@ function! s:fuzzy() abort
   let outputs = tempname()
   let ignores = tempname()
 
+  let s:fuzzy_open_command = ''
+
+  if g:fuzzy_tabopen
+    let s:fuzzy_open_command = 'tab'
+  endif
+
+  if g:fuzzy_jump_if_open
+    let s:fuzzy_open_command .= ' drop' "drop or tab drop
+  else
+    let s:fuzzy_open_command .= 'edit' "edit or tabedit
+  endif
   " Get open buffers.
   let bufs = filter(range(1, bufnr('$')),
     \ 'buflisted(v:val) && bufnr("%") != v:val && bufnr("#") != v:val')
@@ -67,7 +86,7 @@ function! s:fuzzy() abort
 
     let result = readfile(self.outputs)
     if !empty(result)
-      execute 'edit' fnameescape(join(result))
+      execute s:fuzzy_open_command fnameescape(join(result))
     endif
   endfunction
 


### PR DESCRIPTION
This commit adds a new setting:

`g:fuzzy_opencmd` opens the file with the specified command instead of the current
one

Not setting `g:fuzzy_opencmd` is equivalent to setting it to `'edit'`
Examples:
```vim
'edit'      " always opens in current window
'tabedit'   " always opens in new tab
'split'     " always opens in horizontal split
'vsplit'    " always opens in vertical split
'drop'      " open in current window if unopened or jump to if it is open
'tab drop'  " open in new tab if unopened or jump to if it is open (note the space!)
```
Open in (v)split or jump is an exercise for the reader ;-)