### PR TITLE
Pipe lines directly to `fzy`

### DIFF
--- a/plugin/neovim-fuzzy.vim
+++ b/plugin/neovim-fuzzy.vim
@@ -71,13 +71,12 @@ let s:ag = { 'path': 'ag' }
 function! s:ag.find(root, ignorelist) dict
   let ignorefile = tempname()
   call writefile(a:ignorelist, ignorefile, 'w')
-  return systemlist(
-    \ s:ag.path . " --silent --nocolor -g '' -Q --path-to-ignore " . ignorefile . ' ' . a:root)
+  return s:ag.path . " --silent --nocolor -g '' -Q --path-to-ignore " . ignorefile . ' ' . a:root
 endfunction
 
 function! s:ag.find_contents(query) dict
   let query = empty(a:query) ? '^(?=.)' : a:query
-  return systemlist(s:ag.path . " --noheading --nogroup --nocolor -S " . shellescape(query) . " .")
+  return s:ag.path . " --noheading --nogroup --nocolor -S " . shellescape(query) . " ."
 endfunction
 
 "
@@ -90,12 +89,12 @@ function! s:rg.find(root, ignorelist) dict
   for str in a:ignorelist
     call add(ignores, printf("-g '!%s'", str))
   endfor
-  return systemlist(s:rg.path . " --color never --files --fixed-strings " . join(ignores, ' ') . ' ' . a:root . ' 2>/dev/null')
+  return s:rg.path . " --color never --files --fixed-strings " . join(ignores, ' ') . ' ' . a:root . ' 2>/dev/null'
 endfunction
 
 function! s:rg.find_contents(query) dict
   let query = empty(a:query) ? '.' : shellescape(a:query)
-  return systemlist(s:rg.path . " -n --no-heading --color never -S " . query . " . 2>/dev/null")
+  return s:rg.path . " -n --no-heading --color never -S " . query . " . 2>/dev/null"
 endfunction
 
 " Set the finder based on available binaries.
@@ -118,7 +117,7 @@ endfunction
 
 function! s:fuzzy_grep(str) abort
   try
-    let contents = s:fuzzy_source.find_contents(a:str)
+    let contents_cmd = s:fuzzy_source.find_contents(a:str)
   catch
     echoerr v:exception
     return
@@ -135,7 +134,7 @@ function! s:fuzzy_grep(str) abort
     return { 'name': name, 'lnum': lnum }
   endfunction
 
-  return s:fuzzy(contents, opts)
+  return s:fuzzy(contents_cmd, opts)
 endfunction
 
 function! s:fuzzy_open(root) abort
@@ -160,7 +159,7 @@ function! s:fuzzy_open(root) abort
 
   " Get all files, minus the open buffers.
   try
-    let files = s:fuzzy_source.find('.', ignorelist)
+    let files_cmd = s:fuzzy_source.find('.', ignorelist)
   catch
     echoerr v:exception
     return
@@ -169,7 +168,10 @@ function! s:fuzzy_open(root) abort
   endtry
 
   " Put it all together.
-  let result = bufs + files
+  let result = tempname()
+  call writefile(bufs, result)
+  call system(files_cmd . ' >> ' . result)
+  let result = 'cat ' . result
 
   let opts = { 'lines': g:fuzzy_winheight, 'statusfmt': 'FuzzyOpen %s (%d files)', 'root': root }
   function! opts.handler(result)
@@ -179,8 +181,7 @@ function! s:fuzzy_open(root) abort
   return s:fuzzy(result, opts)
 endfunction
 
-function! s:fuzzy(choices, opts) abort
-  let inputs = tempname()
+function! s:fuzzy(choices_cmd, opts) abort
   let outputs = tempname()
 
   if !executable('fzy')
@@ -191,9 +192,10 @@ function! s:fuzzy(choices, opts) abort
   " Clear the command line.
   echo
 
-  call writefile(a:choices, inputs)
-
-  let command = "fzy -l " . a:opts.lines . " > " . outputs . " < " . inputs
+  let fifo_name = tempname()
+  call system(['mkfifo', fifo_name])
+  let command = a:choices_cmd . " | tee " . fifo_name . " | fzy -l " . a:opts.lines . " > " . outputs
+  let num_choices_cmd = 'wc -l ' . fifo_name
   let opts = { 'outputs': outputs, 'handler': a:opts.handler, 'root': a:opts.root }
 
   function! opts.on_exit(id, code, _event) abort
@@ -205,10 +207,12 @@ function! s:fuzzy(choices, opts) abort
     exe 'resize' s:fuzzy_prev_window_height
 
     if a:code != 0 || !filereadable(self.outputs)
+      call delete(self.outputs)
       return
     endif
 
     let result = readfile(self.outputs)
+    call delete(self.outputs)
     if !empty(result)
       let file = self.handler(result)
       exe 'lcd' self.root
@@ -229,10 +233,12 @@ function! s:fuzzy(choices, opts) abort
   else
     exe 'keepalt' g:fuzzy_bufferpos a:opts.lines . 'new'
     let s:fuzzy_job_id = termopen(command, opts)
+    let num_choices = str2nr(system(num_choices_cmd))
+    call delete(fifo_name)
     let b:fuzzy_status = printf(
       \ a:opts.statusfmt,
       \ fnamemodify(opts.root, ':~:.'),
-      \ len(a:choices))
+      \ num_choices)
     setlocal statusline=%{b:fuzzy_status}
   endif
   let s:fuzzy_bufnr = bufnr('%')


### PR DESCRIPTION
Old behavior was loading all the commands into a Vim list, write it into
a file, and pipe that file into `fzy`.

This is a inefficient, because both `ag`/`rg` and `fzy` are blazing fast
and can handle large quantities of data, but Vimscript, with it's
dynamic typing and garbage-collected memory - which aren't even
state-of-the-art! - is not only slowing the entire process down but also
breaks it when doing a big `:FuzzyGrep` in a large codebases.

This PR aims to fix it:

* With `:FuzzyGrep` it pipes the `ag`/`rg` command directly to `fzy`.
* With `:FuzzyOpen` it creates a temporary file, writes the list of
  buffers to it with `writefile()` and then uses `ag`/`rg` to pipe the
  list of files into that temporary file without passing them through
  Vim.

This ensures that aside from the list of buffers(that for obvious
reasons must come from Vim) all the match choices are piped by the
operation system and Vim does not need to load them into it's memory.