### PR TITLE
specify a prompt for fzy invocation

### DIFF
--- a/plugin/neovim-fuzzy.vim
+++ b/plugin/neovim-fuzzy.vim
@@ -128,7 +128,7 @@ function! s:fuzzy_grep(str) abort
     return
   endtry
 
-  let opts = { 'lines': g:fuzzy_winheight, 'statusfmt': 'FuzzyGrep %s (%d results)', 'root': '.' }
+  let opts = { 'lines': g:fuzzy_winheight, 'statusfmt': 'FuzzyGrep %s (%d results)', 'root': '.' , 'prompt': 'grep> '}
 
   function! opts.handler(result) abort
     let parts = split(join(a:result), ':')
@@ -175,7 +175,7 @@ function! s:fuzzy_open(root) abort
   " Put it all together.
   let result = bufs + files
 
-  let opts = { 'lines': g:fuzzy_winheight, 'statusfmt': 'FuzzyOpen %s (%d files)', 'root': root }
+  let opts = { 'lines': g:fuzzy_winheight, 'statusfmt': 'FuzzyOpen %s (%d files)', 'root': root , 'prompt': 'files> ' }
   function! opts.handler(result)
     return { 'name': join(a:result) }
   endfunction
@@ -197,7 +197,7 @@ function! s:fuzzy(choices, opts) abort
 
   call writefile(a:choices, inputs)
 
-  let command = g:fuzzy_executable . " -l " . a:opts.lines . " > " . outputs . " < " . inputs
+  let command = g:fuzzy_executable . " -l " . a:opts.lines . " -p " . shellescape(a:opts.prompt) . " > " . outputs . " < " . inputs
   let opts = { 'outputs': outputs, 'handler': a:opts.handler, 'root': a:opts.root }
 
   function! opts.on_exit(id, code, _event) abort


### PR DESCRIPTION
feel free to reject this, but I get a little confused by the identical appearance of the two modes, so this patch sets the prompt in fzy