### PR TITLE
Admit list argument in ag.find

### DIFF
--- a/plugin/neovim-fuzzy.vim
+++ b/plugin/neovim-fuzzy.vim
@@ -93,8 +93,9 @@ endfunction
 let s:ag = { 'path': 'ag' }
 
 function! s:ag.find(root) dict
-  return systemlist(
-    \ s:ag.path . " --silent --nocolor -g '' -Q " . a:root)
+  return systemlist([
+        \ s:ag.path, "--silent", "--nocolor", "-g", "", "-Q"
+        \ ] + (empty(a:root) ? [] : [a:root]))
 endfunction
 
 function! s:ag.find_contents(query) dict


### PR DESCRIPTION
Since https://github.com/cloudhead/neovim-fuzzy/commit/46f908aedef6af039c5134056ad008fe7aae1cbc `find` expects a list instead of a string and only `rg.find` was updated. This PR adds the missing change to `ag.find`.

I don't know anything about VimL but it Works on My Machine™